### PR TITLE
Reimplemented JSON parsing to avoid the need for line breaks in traffic

### DIFF
--- a/json-rpc.cabal
+++ b/json-rpc.cabal
@@ -23,6 +23,7 @@ library
                         Network.JsonRpc.Conduit
   build-depends:        base                        >= 4.6      && < 5,
                         aeson                       >= 0.7      && < 0.9,
+                        attoparsec                  >= 0.11,
                         async                       >= 2.0      && < 2.1,
                         bytestring                  >= 0.10     && < 0.11,
                         conduit                     >= 1.2      && < 1.3,
@@ -33,6 +34,7 @@ library
                         stm                         >= 2.4      && < 2.5,
                         stm-conduit                 >= 2.5      && < 2.6,
                         text                        >= 0.11     && < 1.3,
+                        transformers                >= 0.3,
                         unordered-containers        >= 0.2      && < 0.3
   default-language:     Haskell2010
   ghc-options:          -Wall


### PR DESCRIPTION
Hello @jprupp,

First of all, thanks for spending your time on json-rpc library and releasing it to public domain. I find it very useful and it's great that the library is independent of the transport allowing me to use it together with network-conduit-tls library.

While using your library I found out that client part relies on JSON RPC server inserting line breaks after every transmitted JSON message. This, unfortunately, isn't always true because it isn't required by JSON RPC spec. This [page](http://www.simple-is-better.org/json-rpc/transport_sockets.html) recommends having a JSON splitter that handles this task by counting braces or by any other means.

So I've reworked a `decodeConduit` method to use attoparsec's partial parsers feature, which allows to run parser sequentially over chunks of inputs. I used code from [jsonrpc-conduit](http://hackage.haskell.org/package/jsonrpc-conduit) as an example of this approach.

The resulting version now doesn't need line break markers and still passes the tests :)

This also required me to introduce dependencies on `attoparsec` and `transformers` packages. I didn't specify upper bounds (and I am not quite sure that lower ones are really lowest possible).

Please review the code to confirm that I didn't break anything and maybe merge it.
