### PR TITLE
JSON-RPC 2.0 methods may return null result.

### DIFF
--- a/Network/JsonRpc/Data.hs
+++ b/Network/JsonRpc/Data.hs
@@ -220,7 +220,9 @@ parseVerIdResultError o = do
     v <- parseVer o
     i <- o .:? "id"
     r <- o .:? "result" .!= Null
-    p <- if r == Null then Left <$> o .: "error" else return $ Right r
+    p <- case v of
+          V1 -> if r == Null then Left <$> o .: "error" else return $ Right r
+          V2 -> maybe (Right r) Left <$> o .:? "error"
     return (v, i, p)
 
 -- | Create a response from a request. Use in servers.


### PR DESCRIPTION
JSON-RPC 2.0 specification says:

> Either the result member or error member MUST be included, but both members MUST NOT be included.

JSON-RPC 2.0 methods may return **null** result, so check error object existence.