### PR TITLE
Resolve dependency breakage

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,4 @@ packages:
 - '.'
 extra-deps: []
 resolver: lts-5.2
+allow-newer: true


### PR DESCRIPTION
Got this error when building the project:
```
Configuring semigroupoids-5.0.1...
setup: At least the following dependencies are missing:
tagged >=0.8.5 && <1 && ==0.8.3
```

This was caused by a revision done to some old Stackage releases:
https://github.com/ekmett/semigroupoids/issues/71
https://github.com/fpco/stackage/issues/3185

It is fixed by relaxing the dependency constraints a bit as suggested
by @ekmett.