### PR TITLE
Assume ErrorVal to be /= Null

### DIFF
--- a/src/Network/JSONRPC/Arbitrary.hs
+++ b/src/Network/JSONRPC/Arbitrary.hs
@@ -34,7 +34,7 @@ instance Arbitrary Response where
 instance Arbitrary ErrorObj where
     arbitrary = oneof
         [ ErrorObj <$> arbitrary <*> arbitrary <*> arbitrary
-        , ErrorVal <$> arbitrary
+        , ErrorVal <$> arbitrary `suchThat` (/= Null)
         ]
 
 instance Arbitrary BatchRequest where


### PR DESCRIPTION
Given the serialization format, the error being null is indistinguishable from there not being an error.

```
Failures:

  test/Spec.hs:35:9:
  1) encoder/decoder checks response fields
       Falsified (after 1 test):
         ResponseError {getResVer = V1, getError = ErrorVal {getErrData = Null}, getResId = IdInt {getIdInt = 9031999554584166487}}

  To rerun use: --match "/encoder/decoder/checks response fields/" --seed 1082620346

  test/Spec.hs:36:9:
  2) encoder/decoder encodes and decodes responses
       Falsified (after 1 test):
         ResponseError {getResVer = V1, getError = ErrorVal {getErrData = Null}, getResId = IdInt {getIdInt = 9031999554584166487}}

  To rerun use: --match "/encoder/decoder/encodes and decodes responses/" --seed 1082620346

Randomized with seed 1082620346

Finished in 41.9827 seconds
17 examples, 2 failures
```

I'm not sure if there should be additional guardrails to avoid this case, now that we excluded it from tests. I was considering changing the type for a second, but I think it's a good idea to be robust against what a potential other party might send.